### PR TITLE
Edmc Overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,12 @@ More information on the [about page](http://elite.laulhere.com/ExTool/index.php?
 * Open the `.zip` archive that you downloaded and move the `ExTool` folder contained inside into the `plugins` folder.
 
 You will need to re-start EDMC for it to notice the new plugin.
+
+## EDMCOverlay
+
+ExTool has support for the [EDMCOverlay](https://github.com/inorton/EDMCOverlay) plugin. 
+If the [EDMCOverlay](https://github.com/inorton/EDMCOverlay) plugin is installed then the details of the current destination are displayed in the HUD
+If you do not install [EDMCOverlay](https://github.com/inorton/EDMCOverlay) then ExTool will work as normal.
+
+
+

--- a/load.py
+++ b/load.py
@@ -18,6 +18,8 @@ from ttkHyperlinkLabel import HyperlinkLabel
 
 from config import config
 import plug
+import overlay
+from overlay import display
 
 this = sys.modules[__name__]
 this.session = requests.Session()
@@ -359,7 +361,7 @@ def updateBearing(latitude, longitude, bearing = None, distance = None):
       this.bearing_status["text"] = "   DEST ({},{}) : Waiting for a screenshot...".format(latitude, longitude)
    else:
       this.bearing_status["text"] = "   DEST ({},{}) : BEARING {} / DIST {} km".format(latitude, longitude, bearing, distance)
-   #this.status.grid(row = 0, column = 1, sticky=tk.W)
+      display(this.bearing_status["text"], 250,730, "yellow", "normal")    
    
    if(this.debug.get()=="1"):
       print datetime.datetime.now().strftime("%H:%M:%S") + " - " + "updateBearing = {} / {}".format(bearing, distance)

--- a/overlay.py
+++ b/overlay.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import datetime
+import time
+
+
+_thisdir = os.path.abspath(os.path.dirname(__file__))
+_overlay_dir = os.path.join(_thisdir, "../EDMCOverlay")
+if _overlay_dir not in sys.path:
+    print "adding {} to sys.path".format(_overlay_dir)
+    sys.path.append(_overlay_dir)
+
+try:
+    import edmcoverlay
+    _overlay = None
+    _overlay = edmcoverlay.Overlay()
+except ImportError:
+    print "ExTool: EDMCOverlay not imported but that is ok"
+    
+
+
+DEFAULT_OVERLAY_MESSAGE_DURATION = 4
+
+def get_display_ttl():
+    try:
+        return int(OVERLAY_MESSAGE_DURATION.get())
+    except:
+        return DEFAULT_OVERLAY_MESSAGE_DURATION
+
+
+time.sleep(2)
+HEADER = 380
+INFO = 420
+DETAIL1 = INFO + 25
+DETAIL2 = DETAIL1 + 25
+DETAIL3 = DETAIL2 + 25
+
+def display(text, row=HEADER, col=80, color="yellow", size="large"):
+    try:
+        _overlay.send_message("extool_{}_{}".format(row, col),
+                              text,
+                              color,
+                              col, row, ttl=get_display_ttl(), size=size)
+    except:
+        #This is going to fail if EDMCOverlay is missing but we don't care
+        pass
+
+
+def header(text):
+    display(text, row=HEADER, size="normal")
+
+
+def notify(text):
+    display(text, row=INFO, color="#00ff00", col=95)
+
+
+def warn(text):
+    display(text, row=INFO, color="red", col=95)
+
+
+def info(line1, line2=None, line3=None):
+    if line1:
+        display(line1, row=DETAIL1, col=95, size="normal")
+    if line2:
+        display(line2, row=DETAIL2, col=95, size="normal")
+    if line3:
+        display(line3, row=DETAIL3, col=95, size="normal")


### PR DESCRIPTION
A new import file is added that adds support for the EDMC overlay plugin.

If EDMC Overlay is installed in the plugins directory then ExTool will display the Heading information on the hud above the compass.

If not installed then there is no change to ExTool behaviour.

![bearing 2](https://user-images.githubusercontent.com/31373535/37493056-8769e7ec-289b-11e8-9943-935f5728ce7a.png)
